### PR TITLE
TRITON-2513 Update status of expired access keys

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -332,7 +332,33 @@ function assertStrictOptions(funcname, opts, expected) {
     }
 }
 
+/*
+ * AccessKeys created before UFDS v7.5.0 may not have status
+ * or created fields. Patch those fields in here so clients
+ * can rely on them being defined.
+ */
+function patchUpAccessKey(accesskey) {
+    if (!accesskey.status) {
+        accesskey.status = 'Inactive';
+    }
 
+    if (!accesskey.updated) {
+        accesskey.updated = accesskey.created;
+    }
+
+    // If a temporary credential is expired, but not yet purged
+    // from UFDS, update the status to reflect that it is expired.
+    if (accesskey.credentialtype &&
+        accesskey.credentialtype === 'temporary') {
+        var now = new Date();
+        var exp = new Date(accesskey.expiration);
+        if (isNaN(exp) || now >= exp) {
+            accesskey.status = 'Expired';
+        }
+    }
+
+    return accesskey;
+}
 
 // --- Exported API
 
@@ -3249,7 +3275,7 @@ function getAccessKey(user, accesskeyid, account, cb, noCache) {
                 return;
             }
             if (keys.length) {
-                cb(null, keys[0]);
+                cb(null, patchUpAccessKey(keys[0]));
                 return;
             }
             cb(new ResourceNotFoundError(accesskeyid + ' does not exist'));
@@ -3309,22 +3335,7 @@ function listAccessKeys(user, account, cb, noCache) {
                 if (err) {
                     next(err);
                 } else {
-
-                    // AccessKeys created before UFDS v7.5.0 may not have status
-                    // or created fields. Patch those fields in here so clients
-                    // can rely on them being defined.
-                    var keys = entries.map(function _mapEntries(entry) {
-                        if (!entry.status) {
-                            entry.status = 'Inactive';
-                        }
-
-                        if (!entry.updated) {
-                            entry.updated = entry.created;
-                        }
-
-                        return entry;
-                    });
-
+                    var keys = entries.map(patchUpAccessKey);
                     next(null, keys);
                 }
             }, noCache);

--- a/lib/index.js
+++ b/lib/index.js
@@ -355,6 +355,9 @@ function patchUpAccessKey(accesskey) {
         if (isNaN(exp) || now >= exp) {
             accesskey.status = 'Expired';
         }
+    } else if (!accesskey.credentialtype) {
+        // Absence of credentialtype makes this a permanent key
+        accesskey.credentialtype = 'permanent';
     }
 
     return accesskey;
@@ -3204,6 +3207,7 @@ UFDS.prototype.addAccessKey = function addAccessKey(user, account, attrs, cb) {
 
             entry.accesskeyid = context.id;
             entry.accesskeysecret = context.secret;
+            entry.credentialtype = 'permanent';
 
             var userUuid = context.user.uuid;
             var dn = (account) ?

--- a/lib/index.js
+++ b/lib/index.js
@@ -3559,8 +3559,17 @@ function updateAccessKey(user, account, accesskey, cb) {
                 'accesskeysecret',
                 'created',
                 'objectclass',
-                'updated'
+                'updated',
+                'credentialtype',
+                'principaluuid',
+                'sessiontoken',
+                'expiration'
             ];
+
+            // Ignore status changes on non-permanent accesskeys
+            if (context.accesskey.credentialtype !== 'permanent') {
+                ignoreAttrs.push('status');
+            }
 
             Object.keys(accesskey).forEach(function _keys(key) {
                 var change = {modification: {}};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ufds",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ufds",
   "author": "Edgecast Cloud (edgecast.io)",
   "description": "Triton UFDS Client API",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "homepage": "https://github.com/TritonDataCenter/triton",
   "repository": {
     "type": "git",


### PR DESCRIPTION
If a temporary accesskey is expired, but not yet purged from UFDS, update the status to reflect that it is expired.
This change is only needed by TritonDataCenter/sdc-cloudapi/pull/153

Also, ignore modification of most attrs for temporary access keys.